### PR TITLE
Makes module name take a form that librarian-puppet likes more

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,4 +1,4 @@
-name 'bmclib'
+name 'logicminds-bmclib'
 version '0.0.1'
 
 author 'Corey Osman'


### PR DESCRIPTION
Seems as though librarian-puppet likes to have the `name` property of a `Modulefile` have the form **username**-**project**. This `Modulefile` was missing a username, so I put in something that seemed appropriate.

For the record, without a user produced:

```
$ librarian-puppet install
/usr/lib/ruby/1.8/puppet/module_tool.rb:37:in `username_and_modname_from': Not a valid full name: bmclib (ArgumentError)
```

probably due to this section in `Puppet::ModuleTool`:

``` ruby
    # Set the full name of this module, and from it, the +username+ and
    # module +name+.
    def full_module_name=(full_module_name)
      @full_module_name = full_module_name
      @username, @name = Puppet::ModuleTool::username_and_modname_from(full_module_name)
    end
```
