### PR TITLE
Make the ipmitool provider properly use arguments in the ruby exec

### DIFF
--- a/lib/puppet/provider/bmc/ipmitool.rb
+++ b/lib/puppet/provider/bmc/ipmitool.rb
@@ -74,7 +74,7 @@ Puppet::Type.type(:bmc).provide(:ipmitool) do
   end
 
   def ipsource=(source)
-    ipmitoolcmd([ 'lan set 1 ipsrc', source ])
+    ipmitoolcmd([ "lan", "set", "1", "ipsrc", source ])
   end
 
   def ip
@@ -82,7 +82,7 @@ Puppet::Type.type(:bmc).provide(:ipmitool) do
   end
 
   def ip=(address)
-    ipmitoolcmd([ 'lan set 1 ipaddr', address ])
+    ipmitoolcmd([ "lan", "set", "1", "ipaddr", address ])
   end
 
   def netmask
@@ -90,7 +90,7 @@ Puppet::Type.type(:bmc).provide(:ipmitool) do
   end
 
   def netmask=(subnet)
-    ipmitoolcmd([ 'lan set 1 netmask', subnet ])
+    ipmitoolcmd([ "lan", "set", "1", "netmask", subnet ])
   end
 
   def gateway
@@ -98,7 +98,7 @@ Puppet::Type.type(:bmc).provide(:ipmitool) do
   end
 
   def gateway=(address)
-    ipmitoolcmd([ 'lan set 1 defgw ipaddr', address ])
+    ipmitoolcmd([ "lan", "set", "1", "defgw", "ipaddr", address ])
   end
 
   def vlanid
@@ -106,7 +106,7 @@ Puppet::Type.type(:bmc).provide(:ipmitool) do
   end
 
   def vlanid=(vid)
-    ipmitoolcmd([ 'lan set 1 vlan id', vid ])
+    ipmitoolcmd([ "lan", "set", "1", "vlan", "id", vid ])
   end
 
   #def snmp
@@ -121,7 +121,7 @@ Puppet::Type.type(:bmc).provide(:ipmitool) do
 
 
   def self.laninfo
-    landata = ipmitoolcmd( 'lan print 1' )
+    landata = ipmitoolcmd([ "lan", "print", "1" ])
     info = {}
     landata.lines.each do |line|
       # clean up the data from spaces
@@ -153,11 +153,11 @@ Puppet::Type.type(:bmc).provide(:ipmitool) do
   end
 
   def enable_channel
-    ipmitoolcmd( 'lan set 1 access on' )
+    ipmitoolcmd([ "lan", "set", "1", "access", "on" ])
   end
 
   def disable_channel
-    ipmitoolcmd( 'lan set 1 access off' )
+    ipmitoolcmd([ "lan", "set", "1", "access", "off" ])
   end
 
   def lanconfig

--- a/lib/puppet/provider/bmcuser/ipmitool.rb
+++ b/lib/puppet/provider/bmcuser/ipmitool.rb
@@ -21,20 +21,20 @@ Puppet::Type.type(:bmcuser).provide(:ipmitool) do
       user = resource[:username]
       id = userid(user)
       if not userexists?(user)
-        ipmitoolcmd([ "user set name", id, user] )
-        ipmitoolcmd([ "user set password", id, resource[:password] ])
-        ipmitoolcmd([ "user priv", id, @priv[resource[:privlevel]], @channel ])
-        ipmitoolcmd([ "user enable", id ])
+        ipmitoolcmd([ "user", "set", "name", id, user] )
+        ipmitoolcmd([ "user", "set", "password", id, resource[:password] ])
+        ipmitoolcmd([ "user", "priv", id, @priv[resource[:privlevel]], @channel ])
+        ipmitoolcmd([ "user", "enable", id ])
 
       else
         if not isenabled?(user)
-          ipmitoolcmd([ "user enable", id ])
+          ipmitoolcmd([ "user", "enable", id ])
         end
         if not privequal?(user)
-          ipmitoolcmd([ "user priv", id, @priv[resource[:privlevel]], @channel ])
+          ipmitoolcmd([ "user", "priv", id, @priv[resource[:privlevel]], @channel ])
         end
         if resource[:force]
-          ipmitoolcmd([ "user set password", id, resource[:password] ])
+          ipmitoolcmd([ "user", "set", "password", id, resource[:password] ])
         end
 
       end
@@ -42,9 +42,9 @@ Puppet::Type.type(:bmcuser).provide(:ipmitool) do
     end
 
     def destroy
-      ipmitoolcmd([ "user set name", id, user ])
-      ipmitoolcmd([ "user priv", id, @priv[:noaccess], @channel ])
-      ipmitoolcmd([ "user disable", id ])
+      ipmitoolcmd([ "user", "set", "name", id, user ])
+      ipmitoolcmd([ "user", "priv", id, @priv[:noaccess], @channel ])
+      ipmitoolcmd([ "user", "disable", id ])
     end
 
     def privequal?(user)
@@ -90,7 +90,7 @@ Puppet::Type.type(:bmcuser).provide(:ipmitool) do
 
     def userlist
       if @users.length < 1
-        userdata = ipmitoolcmd([ "user list 1" ])
+        userdata = ipmitoolcmd([ "user", "list", "1" ])
         @users = parse(userdata)
       end
       return @users
@@ -125,7 +125,7 @@ Puppet::Type.type(:bmcuser).provide(:ipmitool) do
     end
 
     def self.instances
-      userdata = ipmitoolcmd([ "user list 1" ])
+      userdata = ipmitoolcmd([ "user", "list", "1" ])
       userdata.lines.each do | line|
         user = {}
         # skip the header

--- a/spec/unit/puppet/provider/bmc/ipmitool_spec.rb
+++ b/spec/unit/puppet/provider/bmc/ipmitool_spec.rb
@@ -43,9 +43,9 @@ Cipher Suite Priv Max   : XXXXXXXXXXXXXXX
     File.stubs(:exists?).returns(true)
     Puppet::Util.stubs(:which).with("ipmitool").returns("/bin/ipmitool")
     subject.stubs(:which).with("ipmitool").returns("/bin/ipmitool")
-    subject.stubs(:ipmitoolcmd).with("lan print 1").returns(ipmitool_lan_print)
-    subject.stubs(:ipmitoolcmd).with('lan set 1 access on').returns(true)
-    subject.stubs(:ipmitoolcmd).with([ 'lan set 1 ipsrc', 'dhcp' ]).returns(true)
+    subject.stubs(:ipmitoolcmd).with([ "lan", "print", "1"]).returns(ipmitool_lan_print)
+    subject.stubs(:ipmitoolcmd).with([ "lan", "set", "1", "access", "on"]).returns(true)
+    subject.stubs(:ipmitoolcmd).with([ "lan", "set", "1", "ipsrc", "dhcp" ]).returns(true)
 
     @resource =  Puppet::Type::Bmc.new( 
       { :ip       => '192.168.1.34',
@@ -66,14 +66,14 @@ Cipher Suite Priv Max   : XXXXXXXXXXXXXXX
 
   describe 'install' do
     it 'enables the channel' do
-      subject.expects(:ipmitoolcmd).with('lan set 1 access on')
+      subject.expects(:ipmitoolcmd).with(["lan", "set", "1", "access", "on"])
       @provider.install
     end
   end
 
   describe 'ip' do
     it 'should set the ipsource' do
-      subject.expects(:ipmitoolcmd).with([ 'lan set 1 ipsrc', 'dhcp' ])
+      subject.expects(:ipmitoolcmd).with([ "lan", "set", "1", "ipsrc", "dhcp" ])
       @provider.ipsource='dhcp'
     end
   end 


### PR DESCRIPTION
Ruby needs the command line arguments to be in array format, otherwise it ends up execing:

`ipmitool "lan set 1"`

Which ipmitool doesn't like. Hard to debug though, because the debug output formats it into a string, which drops the quotes and array stuff. 

The provider still doesn't work yet, but at least it is executing the correct commands.

Next I'll work on parsing the output in a more robust manner, to get rid of these new `undefined method`strip' for nil:NilClass` errors.
