### PR TITLE
Make the facts timeout.

### DIFF
--- a/lib/facter/bmc.rb
+++ b/lib/facter/bmc.rb
@@ -1,27 +1,27 @@
 #bmc.rb
 
-Facter.add("bmc_ip") do
+Facter.add("bmc_ip", :timeout => 2) do
   confine :is_virtual => :false
   setcode do
     ip
   end
 end
 
-Facter.add("bmc_mac") do
+Facter.add("bmc_mac", :timeout => 2) do
   confine :is_virtual => :false
   setcode do
     mac
   end
 end
 
-Facter.add("bmc_subnet") do
+Facter.add("bmc_subnet", :timeout => 2) do
   confine :is_virtual => :false
   setcode do
    subnet
   end
 end
 
-Facter.add("bmc_gateway") do
+Facter.add("bmc_gateway", :timeout => 2) do
   confine :is_virtual => :false
   setcode do
    gateway


### PR DESCRIPTION
Fixes when ipmitool freezes and you never get a puppet run.
