### PR TITLE
name for init script on debian is openipmi, not ipmi

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,24 +32,27 @@ class bmclib (
     'Debian': {
       $freeipmi = 'freeipmi-tools'
       $openipmi = 'openipmi'
+      $service_name = 'openipmi'
 
       file { '/etc/default/ipmi':
         ensure => 'present',
-        notify => Service['ipmi'],
+        notify => Service[$service_name],
         content => 'ENABLED=true',
       }
     }
     'RedHat': {
       $openipmi = 'OpenIPMI'
+      $service_name = 'ipmi'
 
       file { '/etc/sysconfig/ipmi':
         ensure => 'present',
-        notify => Service['ipmi'],
+        notify => Service[$service_name],
       }
     }
     default: {
       $freeipmi = 'freeipmi'
       $openipmi = 'OpenIPMI'
+      $service_name = 'ipmi'
     }
   }
 
@@ -63,7 +66,7 @@ class bmclib (
     ensure => $package_ensure,
   }
 
-  service { 'ipmi':
+  service { $service_name:
     ensure     => $service_ensure,
     enable     => true,
     hasrestart => true,

--- a/spec/classes/bmclib_init_spec.rb
+++ b/spec/classes/bmclib_init_spec.rb
@@ -57,7 +57,7 @@ describe 'bmclib', :type => 'class' do
       :ensure => 'present',
       :name   => 'openipmi'
     )}
-    it { should contain_service('ipmi').with(
+    it { should contain_service('openipmi').with(
       :ensure     => 'running',
       :enable     => 'true',
       :hasrestart => 'true',
@@ -68,7 +68,7 @@ describe 'bmclib', :type => 'class' do
       :ensure  => 'present',
       :path    => '/etc/default/ipmi',
       :content => 'ENABLED=true',
-      :notify  => 'Service[ipmi]'
+      :notify  => 'Service[openipmi]'
     )}
     it 'should contain File[/etc/default/ipmi] with contents "ENABLED=true"' do
       verify_contents(subject, '/etc/default/ipmi', [


### PR DESCRIPTION
The name of the actual script in /etc/init.d on Debian distros is openipmi, not ipmi. We had an internal manual fix for this but it's better to just switch on the service name based on distro.
