### PR TITLE
Add a bmc_detected fact.

### DIFF
--- a/lib/facter/bmc.rb
+++ b/lib/facter/bmc.rb
@@ -1,5 +1,12 @@
 #bmc.rb
 
+Facter.add("bmc_detected", :timeout => 2) do
+  confine :is_virtual => :false
+  setcode do
+    not lanconfig.empty?
+  end
+end
+
 Facter.add("bmc_ip", :timeout => 2) do
   confine :is_virtual => :false
   setcode do


### PR DESCRIPTION
This is useful for use with strict_variables, where it is not possible
to use logic like !$::bmc_ip to test for the presence of a BMC.
